### PR TITLE
Ensure pixel aspect ratio of 8:7

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,17 @@
 
             /* REQUIRED BY NINJAPAD */
             #emu-screen {
-                width: 256px;
-                max-width: 768px;
-                height: 240px;
-                max-height: 720px;
+                --screen-width: 256;
+                --screen-height: 240;
+                --pixel-ratio: calc(8 / 7);
+                --max-scale: 3;
+                max-width: calc(var(--screen-width) * var(--max-scale) * var(--pixel-ratio))px;
+                max-height: calc(var(--screen-height) * var(--max-scale))px;
                 position: relative;
                 margin: auto;
+                aspect-ratio: calc(var(--screen-width) * var(--pixel-ratio) / var(--screen-height));
+                object-fit: contain;
+                overflow: clip;
             }
 
             #emu-canvas {

--- a/ninjapad/layout.js
+++ b/ninjapad/layout.js
@@ -62,16 +62,15 @@ ninjapad.layout = function() {
         var useJQuery = !ninjapad.utils.isFullScreen() || ninjapad.utils.isIOSDevice();
         var width = useJQuery ? $(window).width() : window.innerWidth;
         var height = useJQuery ? $(window).height() : window.innerHeight;
+        var aspectRatio = (256 / 240) * (8 / 7);
 
-        if (width > height) {
+        if (width / height > aspectRatio) {
+            elm.emuScreen.width("auto");
             elm.emuScreen.height("100%");
-            var newHeight = elm.emuScreen.height();
-            elm.emuScreen.width(emuScrWidth * (newHeight / emuScrHeight));
         }
         else {
             elm.emuScreen.width("100%");
-            var newWidth = elm.emuScreen.width();
-            elm.emuScreen.height(emuScrHeight * (newWidth / emuScrWidth));
+            elm.emuScreen.height("auto");
         }
         elm.gamepad.height("0%");
         elm.gamepadButtons.hide();
@@ -149,8 +148,7 @@ ninjapad.layout = function() {
             var bottom = "auto";
 
             elm.emuScreen.width(window.innerWidth);
-            var newWidth = elm.emuScreen.width();
-            elm.emuScreen.height(emuScrHeight * (newWidth / emuScrWidth));
+            elm.emuScreen.height("auto");
 
             var padHeight = ninjapad.utils.vw(47.5);
             var remainingHeight = height - elm.emuScreen.height();
@@ -182,9 +180,8 @@ ninjapad.layout = function() {
             elm.screen.detach().appendTo("#GAMEPAD");
 
             // Set the EMULATION_SCREEN element height to 100%
+            elm.emuScreen.width("auto");
             elm.emuScreen.height("100%"); //("90%");
-            var newHeight = elm.emuScreen.height();
-            elm.emuScreen.width(emuScrWidth * (newHeight / emuScrHeight));
 
             // Center the SCREEN element vertically
             elm.gamepad.css("display", "flex");


### PR DESCRIPTION
This was mentioned on the nesdev discord so I took a stab at implementing it. I used the [240p test suite](https://github.com/pinobatch/240p-test-mini) to check for the proper pixel aspect ratio.

Let me know what you think! One thing I noticed is that this will shrink the height of the screen in portrait mode on a phone, which will move the virtual buttons up a bit. So maybe it would make sense to add some padding on top of the screen, or even an option to use 1:1 pixel aspect ratio instead.