### PR TITLE
Switchable pixel aspect ratio between 1:1 and 8:7

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
                 max-height: 720px;
                 position: relative;
                 margin: auto;
+                object-fit: contain;
+                overflow: clip;
             }
 
             #emu-canvas {

--- a/ninjapad/config/settings.js
+++ b/ninjapad/config/settings.js
@@ -10,6 +10,8 @@ const GAMEBOY_LAYOUT = true;
 // Emulation screen
 const EMULATION_SCREEN = "emu-screen";
 const EMULATION_DISPLAY = "emu-canvas";
+const PIXEL_MODE = "SQUARE";  // use "NTSC" for 8:7 pixel aspect ratio.
+const MAX_SCREEN_SCALE = 3;
 
 // Emulation settings
 const SYSTEM = "nes";

--- a/ninjapad/layout.js
+++ b/ninjapad/layout.js
@@ -89,7 +89,7 @@ ninjapad.layout = function() {
         var useJQuery = !ninjapad.utils.isFullScreen() || ninjapad.utils.isIOSDevice();
         var width = useJQuery ? $(window).width() : window.innerWidth;
         var height = useJQuery ? $(window).height() : window.innerHeight;
-        var aspectRatio = updatePixelMode();
+        updatePixelMode();
 
         if (width / height > aspectRatio) {
             elm.emuScreen.width("auto");

--- a/ninjapad/layout.js
+++ b/ninjapad/layout.js
@@ -8,6 +8,8 @@ ninjapad.layout = function() {
     var emuScrHeight;
     var isGBLayout;
     var coldStart = true;
+    var pixelMode;
+    var aspectRatio;
 
     function setOSDLayout() {
 
@@ -56,22 +58,46 @@ ninjapad.layout = function() {
         elm.emuScreen.css("position", "relative");
     }
 
+    function updatePixelMode() {
+        switch (pixelMode) {
+            case "SQUARE":
+            default:
+                pixelAspectRatio = 1;
+                break;
+            case "NTSC":
+                pixelAspectRatio = 8 / 7;
+                break;
+        }
+        aspectRatio = (256 / 240) * pixelAspectRatio;
+        elm.emuScreen.css("max-width", `${256 * MAX_SCREEN_SCALE * pixelAspectRatio}px`);
+        elm.emuScreen.css("max-height", `${240 * MAX_SCREEN_SCALE}px`);
+        elm.emuScreen.css("aspect-ratio", `${aspectRatio} / 1`);
+
+        // Copied from setOSDLayout() above.
+        const scrHeight = elm.emuScreen.height();
+        const scrWidth = elm.emuScreen.width();
+        elm.osd.css("height", scrHeight);
+        elm.osd.css("width", scrWidth);
+        elm.osd.css("font-size", 0.05 * scrHeight);
+        elm.recMenu.css("font-size", 0.05 * scrHeight);
+        elm.recStatus.css("font-size", 0.05 * scrHeight);
+    }
+
     function setDesktopLayout() {
         DEBUG && console.log("NinjaPad: Desktop mode selected");
 
         var useJQuery = !ninjapad.utils.isFullScreen() || ninjapad.utils.isIOSDevice();
         var width = useJQuery ? $(window).width() : window.innerWidth;
         var height = useJQuery ? $(window).height() : window.innerHeight;
+        var aspectRatio = updatePixelMode();
 
-        if (width > height) {
+        if (width / height > aspectRatio) {
+            elm.emuScreen.width("auto");
             elm.emuScreen.height("100%");
-            var newHeight = elm.emuScreen.height();
-            elm.emuScreen.width(emuScrWidth * (newHeight / emuScrHeight));
         }
         else {
             elm.emuScreen.width("100%");
-            var newWidth = elm.emuScreen.width();
-            elm.emuScreen.height(emuScrHeight * (newWidth / emuScrWidth));
+            elm.emuScreen.height("auto");
         }
         elm.gamepad.height("0%");
         elm.gamepadButtons.hide();
@@ -109,6 +135,7 @@ ninjapad.layout = function() {
             elm.recStatus.detach().appendTo(elm.emuScreen);
             $("body *").not("#ninjaPad *").not("#ninjaPad").remove();
             isGBLayout = GAMEBOY_LAYOUT;
+            pixelMode = PIXEL_MODE;
             coldStart = false;
         }
 
@@ -117,6 +144,7 @@ ninjapad.layout = function() {
         var useJQuery = !ninjapad.utils.isFullScreen() || ninjapad.utils.isIOSDevice();
         var width = useJQuery ? $(window).width() : window.innerWidth;
         var height = useJQuery ? $(window).height() : window.innerHeight;
+        updatePixelMode();
 
         const functionalLeft = $("#FUNCTIONAL-BL");
         const functionalRight = $("#FUNCTIONAL-TR");
@@ -149,8 +177,7 @@ ninjapad.layout = function() {
             var bottom = "auto";
 
             elm.emuScreen.width(window.innerWidth);
-            var newWidth = elm.emuScreen.width();
-            elm.emuScreen.height(emuScrHeight * (newWidth / emuScrWidth));
+            elm.emuScreen.height("auto");
 
             var padHeight = ninjapad.utils.vw(47.5);
             var remainingHeight = height - elm.emuScreen.height();
@@ -182,9 +209,8 @@ ninjapad.layout = function() {
             elm.screen.detach().appendTo("#GAMEPAD");
 
             // Set the EMULATION_SCREEN element height to 100%
+            elm.emuScreen.width("auto");
             elm.emuScreen.height("100%"); //("90%");
-            var newHeight = elm.emuScreen.height();
-            elm.emuScreen.width(emuScrWidth * (newHeight / emuScrHeight));
 
             // Center the SCREEN element vertically
             elm.gamepad.css("display", "flex");
@@ -282,6 +308,15 @@ ninjapad.layout = function() {
     return {
         toggleABLayout: function() {
             setABLayout(true);
+        },
+
+        getPixelMode: function() {
+            return pixelMode;
+        },
+
+        setPixelMode: function(mode) {
+            pixelMode = mode;
+            updatePixelMode();
         },
 
         setPageLayout: function() {

--- a/ninjapad/menu.js
+++ b/ninjapad/menu.js
@@ -6,10 +6,12 @@ ninjapad.menu = function() {
     const pop = ninjapad.utils.pop;
     const inColor = ninjapad.utils.inColor;
     const iRModes = ["OFF", "ON-S", "ON-R"];
+    const pixelModes = ["SQUARE", "NTSC"];
 
     var countdown = null;
     var isOpen = false;
     var iRMode = 0;
+    var pixelModeIndex = 0;
 
     var fnESC = null;
     var fnESCArgs = [];
@@ -54,6 +56,9 @@ ninjapad.menu = function() {
     }
 
     function optionsMenu() {
+        pixelModeIndex = pixelModes.indexOf(ninjapad.layout.getPixelMode());
+        if (pixelModeIndex == -1) pixelModeIndex = 0;
+
         return ninjapad.utils.createMenu(null,
             ninjapad.utils.link(
                 "Export save data",
@@ -73,7 +78,11 @@ ninjapad.menu = function() {
             ninjapad.utils.link(
                 "Toggle button layout",
                 js="ninjapad.layout.toggleABLayout()"
-            )
+            ),
+            ninjapad.utils.link(
+                `Pixel mode ${inColor("lime", pixelModes[pixelModeIndex])}`,
+                js="ninjapad.menu.selectPixelMode(); ninjapad.menu.show.optionsMenu()"
+            ),
         );
     }
 
@@ -576,6 +585,15 @@ ninjapad.menu = function() {
                     ninjapad.elements.recStatus.hide();
                 }
             }
-        }
+        },
+
+        selectPixelMode: function(mode) {
+            pixelModeIndex = (
+                mode == undefined ?
+                ninjapad.utils.nextIndex(pixelModes, pixelModeIndex) :
+                mode < 0 ? pixelModeIndex : mode
+            );
+            ninjapad.layout.setPixelMode(pixelModes[pixelModeIndex]);
+        },
     }
 }();

--- a/ninjapad/menu.js
+++ b/ninjapad/menu.js
@@ -76,12 +76,12 @@ ninjapad.menu = function() {
                 hide=!INPUT_RECORDER
             ),
             ninjapad.utils.link(
-                "Toggle button layout",
-                js="ninjapad.layout.toggleABLayout()"
-            ),
-            ninjapad.utils.link(
                 `Pixel mode ${inColor("lime", pixelModes[pixelModeIndex])}`,
                 js="ninjapad.menu.selectPixelMode(); ninjapad.menu.show.optionsMenu()"
+            ),
+            ninjapad.utils.link(
+                "Toggle button layout",
+                js="ninjapad.layout.toggleABLayout()"
             ),
         );
     }


### PR DESCRIPTION
A pixel ratio of 8:7 is more correct, but uses less screen space, so sometimes it is nice to allow 1:1 as well.

This allows the user to switch between the two, but the default can be chosen in the settings.

I originally put "8:7" and "1:1" in the option names, but the ":" glyph is not available in that option screen font. So instead I used the names "SQUARE" -> 1:1, "NTSC" -> 8:7.